### PR TITLE
Update DeclarativeBase and clarify PLR ontology fields

### DIFF
--- a/praxis/backend/database_models/asset_management_orm.py
+++ b/praxis/backend/database_models/asset_management_orm.py
@@ -9,20 +9,17 @@ SQLAlchemy ORM models for Asset Management, including:
 - DeckConfigurationOrm (Named deck layouts)
 - DeckConfigurationSlotItemOrm (Labware in a slot for a layout)
 """
-from sqlalchemy import (
-    Column, Integer, String, Text, Boolean, ForeignKey, JSON, DateTime, UniqueConstraint, Enum as SAEnum, Float
-)
-from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
+from datetime import datetime
+from typing import Optional
 import enum
 
-# TODO: DB-SETUP-1 (Asset ORM): Ensure this import path for Base is correct for your project structure.
-try:
-    from praxis.backend.utils.db import Base # Import your project's Base
-except ImportError:
-    print("WARNING: Could not import Base from praxis.backend.utils.db. Using a local Base for Asset ORM definition only.")
-    from sqlalchemy.orm import declarative_base
-    Base = declarative_base()
+from sqlalchemy import (
+    Integer, String, Text, Boolean, ForeignKey, JSON, DateTime, UniqueConstraint, Enum as SAEnum, Float
+)
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from praxis.backend.utils.db import Base # Import your project's Base
 
 # --- Enum Definitions for Asset Status Fields ---
 class ManagedDeviceStatusEnum(enum.Enum):
@@ -67,26 +64,26 @@ class AssetInstanceOrm(Base):
   """
   __tablename__ = "asset_instances"
 
-  id = Column(Integer, primary_key=True, index=True)
-  asset_type = Column(String, nullable=False, index=True)  # 'device', 'labware', etc.
-  asset_id = Column(Integer, nullable=False, index=True)  # FK to concrete asset table (interpreted based on asset_type)
+  id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+  asset_type: Mapped[str] = mapped_column(String, nullable=False, index=True)  # 'device', 'labware', etc.
+  asset_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)  # FK to concrete asset table (interpreted based on asset_type)
 
-  barcode = Column(String, nullable=True, unique=True, index=True)
-  serial_number = Column(String, nullable=True, unique=True, index=True)
+  barcode: Mapped[Optional[str]] = mapped_column(String, nullable=True, unique=True, index=True)
+  serial_number: Mapped[Optional[str]] = mapped_column(String, nullable=True, unique=True, index=True)
 
-  acquisition_date = Column(DateTime(timezone=True), nullable=True)
-  warranty_expiry = Column(DateTime(timezone=True), nullable=True)
-  last_maintenance = Column(DateTime(timezone=True), nullable=True)
-  next_maintenance_due = Column(DateTime(timezone=True), nullable=True)
+  acquisition_date: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+  warranty_expiry: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+  last_maintenance: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+  next_maintenance_due: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
-  owner = Column(String, nullable=True)  # Person or group responsible for this asset
+  owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # Person or group responsible for this asset
   #cost_center = Column(String, nullable=True)
   #purchase_value = Column(Float, nullable=True)
 
-  metadata_json = Column(JSON, nullable=True, comment="Additional asset metadata")
+  metadata_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="Additional asset metadata")
 
-  created_at = Column(DateTime(timezone=True), server_default=func.now())
-  updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+  created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+  updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
   __table_args__ = (
     UniqueConstraint('asset_type', 'asset_id', name='uq_asset_instance'),
@@ -98,25 +95,25 @@ class AssetInstanceOrm(Base):
 class ManagedDeviceOrm(Base):
     __tablename__ = "managed_devices"
 
-    id = Column(Integer, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     # praxis_device_id = Column(String, unique=True, index=True, nullable=False, comment="Unique identifier within Praxis, e.g., Serial Number or user-defined ID")
-    user_friendly_name = Column(String, nullable=False, unique=True, index=True)
-    pylabrobot_class_name = Column(String, nullable=False, comment="Fully qualified PyLabRobot class name (e.g., pylabrobot.liquid_handling.hamilton.STAR)")
-    praxis_device_category = Column(SAEnum(PraxisDeviceCategoryEnum, name="praxis_device_category_enum"), nullable=True, index=True, comment="Praxis-defined category based on PLR class")
-    backend_config_json = Column(JSON, nullable=True, comment="JSON storing PLR backend connection details")
+    user_friendly_name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    pylabrobot_class_name: Mapped[str] = mapped_column(String, nullable=False, comment="Fully qualified PyLabRobot class name (e.g., pylabrobot.liquid_handling.hamilton.STAR)")
+    praxis_device_category: Mapped[Optional[PraxisDeviceCategoryEnum]] = mapped_column(SAEnum(PraxisDeviceCategoryEnum, name="praxis_device_category_enum"), nullable=True, index=True, comment="Praxis-defined category based on PLR class")
+    backend_config_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="JSON storing PLR backend connection details")
 
-    current_status = Column(SAEnum(ManagedDeviceStatusEnum, name="managed_device_status_enum"), default=ManagedDeviceStatusEnum.OFFLINE, nullable=False)
-    status_details = Column(Text, nullable=True, comment="More details on error or current operation")
-    current_protocol_run_guid = Column(String, ForeignKey("protocol_runs.run_guid", ondelete="SET NULL"), nullable=True, index=True) # Link to ProtocolRunOrm.run_guid
+    current_status: Mapped[ManagedDeviceStatusEnum] = mapped_column(SAEnum(ManagedDeviceStatusEnum, name="managed_device_status_enum"), default=ManagedDeviceStatusEnum.OFFLINE, nullable=False)
+    status_details: Mapped[Optional[str]] = mapped_column(Text, nullable=True, comment="More details on error or current operation")
+    current_protocol_run_guid: Mapped[Optional[str]] = mapped_column(String, ForeignKey("protocol_runs.run_guid", ondelete="SET NULL"), nullable=True, index=True) # Link to ProtocolRunOrm.run_guid
 
     # TODO: ASSET-DB-1: Define WorkcellOrm if supporting multiple workcells and link here.
-    workcell_id = Column(Integer, nullable=True, index=True, comment="FK to a future Workcells table")
-    physical_location_description = Column(String, nullable=True)
-    properties_json = Column(JSON, nullable=True, comment="Additional device-specific properties, calibration data")
+    workcell_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True, comment="FK to a future Workcells table")
+    physical_location_description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    properties_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="Additional device-specific properties, calibration data")
 
-    last_seen_online = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    last_seen_online: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     # Relationship to protocol runs (if a device is associated with a run, e.g. the main robot)
     # protocol_run = relationship("ProtocolRunOrm", foreign_keys=[current_protocol_run_guid]) # Needs careful thought if run_guid is used as FK
@@ -134,29 +131,29 @@ class ManagedDeviceOrm(Base):
 class LabwareDefinitionCatalogOrm(Base): # TODO: ASSET-DB-2: Bring in line with PLR labware definition
     __tablename__ = "labware_definition_catalog"
 
-    pylabrobot_definition_name = Column(String, primary_key=True, index=True, comment="Unique name from PyLabRobot (e.g., corning_96_wellplate_360ul_flat), corresponds to PLR Resource.name")
-    python_fqn = Column(String, nullable=False, index=True, comment="Fully qualified Python class name for this labware definition (e.g., pylabrobot.resources.plate.Plate)")
+    pylabrobot_definition_name: Mapped[str] = mapped_column(String, primary_key=True, index=True, comment="Unique name from PyLabRobot (e.g., corning_96_wellplate_360ul_flat), corresponds to PLR Resource.name")
+    python_fqn: Mapped[str] = mapped_column(String, nullable=False, index=True, comment="Fully qualified Python class name of the specific PyLabRobot resource definition (e.g., 'pylabrobot.resources.corning_96_wellplate_360ul_flat.Corning96WellPlate360uLFlat', or 'pylabrobot.resources.plate.Plate' if generic).")
 
     # Fields for PLR Resource base attributes
-    size_x_mm = Column(Float, nullable=True, comment="Dimension X in millimeters, from PLR Resource.size_x")
-    size_y_mm = Column(Float, nullable=True, comment="Dimension Y in millimeters, from PLR Resource.size_y")
-    size_z_mm = Column(Float, nullable=True, comment="Dimension Z in millimeters, from PLR Resource.size_z")
-    plr_category = Column(String, nullable=True, index=True, comment="Category string from PLR Resource.category")
-    model = Column(String, nullable=True, comment="Model identifier, from PLR Resource.model")
-    rotation_json = Column(JSON, nullable=True, comment="Represents PLR Resource.rotation, e.g., {'x_deg': 0, 'y_deg': 0, 'z_deg': 90} or PLR rotation object serialized")
+    size_x_mm: Mapped[Optional[float]] = mapped_column(Float, nullable=True, comment="Dimension X in millimeters, from PLR Resource.size_x")
+    size_y_mm: Mapped[Optional[float]] = mapped_column(Float, nullable=True, comment="Dimension Y in millimeters, from PLR Resource.size_y")
+    size_z_mm: Mapped[Optional[float]] = mapped_column(Float, nullable=True, comment="Dimension Z in millimeters, from PLR Resource.size_z")
+    plr_category: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True, comment="Specific PyLabRobot resource class name (e.g., 'Plate', 'TipRack', 'Carrier', 'Trough') from the PLR ontology. Corresponds to PLR Resource.category or the direct subclass name.")
+    model: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="Model identifier, from PLR Resource.model")
+    rotation_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="Represents PLR Resource.rotation, e.g., {'x_deg': 0, 'y_deg': 0, 'z_deg': 90} or PLR rotation object serialized")
 
     # Existing Praxis-specific or other fields
-    praxis_labware_type_name = Column(String, nullable=True, unique=True, comment="Optional user-friendly alias in Praxis")
-    description = Column(Text, nullable=True)
-    is_consumable = Column(Boolean, default=True)
-    nominal_volume_ul = Column(Float, nullable=True)
-    material = Column(String, nullable=True)
-    manufacturer = Column(String, nullable=True)
+    praxis_labware_type_name: Mapped[Optional[str]] = mapped_column(String, nullable=True, unique=True, comment="Optional user-friendly alias in Praxis")
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_consumable: Mapped[bool] = mapped_column(Boolean, default=True)
+    nominal_volume_ul: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    material: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    manufacturer: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
-    plr_definition_details_json = Column(JSON, nullable=True, comment="Additional PLR-specific details not covered by dedicated columns (e.g., well layout, specific geometry details)")
+    plr_definition_details_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="Additional PLR-specific details not covered by dedicated columns (e.g., well layout, specific geometry details)")
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     labware_instances = relationship("LabwareInstanceOrm", back_populates="labware_definition")
 
@@ -167,33 +164,33 @@ class LabwareDefinitionCatalogOrm(Base): # TODO: ASSET-DB-2: Bring in line with 
 class LabwareInstanceOrm(Base):
     __tablename__ = "labware_instances"
 
-    id = Column(Integer, primary_key=True, index=True) # praxis_labware_instance_id
-    user_assigned_name = Column(String, nullable=False, unique=True, index=True, comment="User-friendly unique name for this physical item")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True) # praxis_labware_instance_id
+    user_assigned_name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True, comment="User-friendly unique name for this physical item")
 
-    pylabrobot_definition_name = Column(String, ForeignKey("labware_definition_catalog.pylabrobot_definition_name"), nullable=False, index=True)
+    pylabrobot_definition_name: Mapped[str] = mapped_column(String, ForeignKey("labware_definition_catalog.pylabrobot_definition_name"), nullable=False, index=True)
 
-    lot_number = Column(String, nullable=True)
-    expiry_date = Column(DateTime(timezone=True), nullable=True) # Use DateTime for date part
-    date_added_to_inventory = Column(DateTime(timezone=True), server_default=func.now())
+    lot_number: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    expiry_date: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True) # Use DateTime for date part
+    date_added_to_inventory: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
-    current_status = Column(SAEnum(LabwareInstanceStatusEnum, name="labware_instance_status_enum"), default=LabwareInstanceStatusEnum.UNKNOWN, nullable=False, index=True)
-    status_details = Column(Text, nullable=True, comment="Additional details about the current status, e.g., error message") # ADDED
+    current_status: Mapped[LabwareInstanceStatusEnum] = mapped_column(SAEnum(LabwareInstanceStatusEnum, name="labware_instance_status_enum"), default=LabwareInstanceStatusEnum.UNKNOWN, nullable=False, index=True)
+    status_details: Mapped[Optional[str]] = mapped_column(Text, nullable=True, comment="Additional details about the current status, e.g., error message") # ADDED
 
     # Location tracking
     # If on a deck, deck_device_id + current_deck_slot_name should be set.
     # If inside another device (e.g. plate in reader), location_device_id is set.
     # If in general storage, physical_location_description can be used.
-    current_deck_slot_name = Column(String, nullable=True, comment="If on a deck, the slot name (e.g., A1, SLOT_7)")
-    location_device_id = Column(Integer, ForeignKey("managed_devices.id"), nullable=True, comment="FK to ManagedDeviceOrm if located on/in a device (deck, reader, etc.)")
-    physical_location_description = Column(String, nullable=True, comment="General storage location if not on a device")
+    current_deck_slot_name: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="If on a deck, the slot name (e.g., A1, SLOT_7)")
+    location_device_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("managed_devices.id"), nullable=True, comment="FK to ManagedDeviceOrm if located on/in a device (deck, reader, etc.)")
+    physical_location_description: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="General storage location if not on a device")
 
-    properties_json = Column(JSON, nullable=True, comment="Instance-specific state (e.g., well contents, used tips map)")
-    is_permanent_fixture = Column(Boolean, default=False, comment="e.g., built-in waste chute")
+    properties_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True, comment="Instance-specific state (e.g., well contents, used tips map)")
+    is_permanent_fixture: Mapped[bool] = mapped_column(Boolean, default=False, comment="e.g., built-in waste chute")
 
-    current_protocol_run_guid = Column(String, ForeignKey("protocol_runs.run_guid", ondelete="SET NULL"), nullable=True, index=True)
+    current_protocol_run_guid: Mapped[Optional[str]] = mapped_column(String, ForeignKey("protocol_runs.run_guid", ondelete="SET NULL"), nullable=True, index=True)
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     labware_definition = relationship("LabwareDefinitionCatalogOrm", back_populates="labware_instances")
     location_device = relationship("ManagedDeviceOrm", back_populates="located_labware_instances")
@@ -210,15 +207,15 @@ class LabwareInstanceOrm(Base):
 class DeckConfigurationOrm(Base):
     __tablename__ = "deck_configurations"
 
-    id = Column(Integer, primary_key=True, index=True) # praxis_deck_config_id
-    layout_name = Column(String, nullable=False, unique=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True) # praxis_deck_config_id
+    layout_name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
 
     # A Deck itself is a ManagedDevice
-    deck_device_id = Column(Integer, ForeignKey("managed_devices.id"), nullable=False)
-    description = Column(Text, nullable=True)
+    deck_device_id: Mapped[int] = mapped_column(Integer, ForeignKey("managed_devices.id"), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     deck_device = relationship("ManagedDeviceOrm", back_populates="deck_configurations")
     slot_items = relationship("DeckConfigurationSlotItemOrm", back_populates="deck_configuration", cascade="all, delete-orphan")
@@ -230,15 +227,15 @@ class DeckConfigurationOrm(Base):
 class DeckConfigurationSlotItemOrm(Base):
     __tablename__ = "deck_configuration_slot_items"
 
-    id = Column(Integer, primary_key=True, index=True)
-    deck_configuration_id = Column(Integer, ForeignKey("deck_configurations.id"), nullable=False)
-    slot_name = Column(String, nullable=False, comment="Slot name on the deck (e.g., A1, SLOT_7)")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    deck_configuration_id: Mapped[int] = mapped_column(Integer, ForeignKey("deck_configurations.id"), nullable=False)
+    slot_name: Mapped[str] = mapped_column(String, nullable=False, comment="Slot name on the deck (e.g., A1, SLOT_7)")
 
     # This links to a specific physical piece of labware
-    labware_instance_id = Column(Integer, ForeignKey("labware_instances.id"), nullable=False)
+    labware_instance_id: Mapped[int] = mapped_column(Integer, ForeignKey("labware_instances.id"), nullable=False)
 
     # Optional: for validation, store the expected type of labware for this slot in this layout
-    expected_labware_definition_name = Column(String, ForeignKey("labware_definition_catalog.pylabrobot_definition_name"), nullable=True)
+    expected_labware_definition_name: Mapped[Optional[str]] = mapped_column(String, ForeignKey("labware_definition_catalog.pylabrobot_definition_name"), nullable=True)
 
     deck_configuration = relationship("DeckConfigurationOrm", back_populates="slot_items")
     labware_instance = relationship("LabwareInstanceOrm", back_populates="deck_configuration_items")

--- a/praxis/backend/database_models/protocol_definitions_orm.py
+++ b/praxis/backend/database_models/protocol_definitions_orm.py
@@ -10,21 +10,17 @@ SQLAlchemy ORM models for storing:
 
 Version 3: Imports Base from praxis.utils.db.
 """
-from sqlalchemy import (
-    Column, Integer, String, Text, Boolean, ForeignKey, JSON, DateTime, UniqueConstraint, Enum as SAEnum
-)
-from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
+from datetime import datetime
+from typing import Optional, Any # Any can be used for JSON if type is not strictly dict/list
 import enum
 
-# TODO: DB-SETUP-1: Ensure this import path for Base is correct for your project structure.
-# Assuming your existing db.py has a Base = declarative_base()
-try:
-    from praxis.backend.utils.db import Base # Import your project's Base
-except ImportError:
-    print("WARNING: Could not import Base from praxis.backend.utils.db. Using a local Base for model definition only.")
-    from sqlalchemy.orm import declarative_base
-    Base = declarative_base()
+from sqlalchemy import (
+    Integer, String, Text, Boolean, ForeignKey, JSON, DateTime, UniqueConstraint, Enum as SAEnum
+)
+from sqlalchemy.orm import relationship, Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from praxis.backend.utils.db import Base # Import your project's Base
 
 
 # --- Enum Definitions for Status Fields ---
@@ -54,16 +50,16 @@ class FunctionCallStatusEnum(enum.Enum):
 # --- Protocol Source Tables ---
 class ProtocolSourceRepositoryOrm(Base):
     __tablename__ = "protocol_source_repositories"
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False, unique=True, index=True)
-    git_url = Column(String, nullable=False)
-    default_ref = Column(String, nullable=False, default="main")
-    local_checkout_path = Column(String, nullable=True)
-    last_synced_commit = Column(String, nullable=True)
-    status = Column(SAEnum(ProtocolSourceStatusEnum, name="ps_status_enum_repo_v3"), default=ProtocolSourceStatusEnum.ACTIVE, nullable=False)
-    auto_sync_enabled = Column(Boolean, default=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    git_url: Mapped[str] = mapped_column(String, nullable=False)
+    default_ref: Mapped[str] = mapped_column(String, nullable=False, default="main")
+    local_checkout_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    last_synced_commit: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    status: Mapped[ProtocolSourceStatusEnum] = mapped_column(SAEnum(ProtocolSourceStatusEnum, name="ps_status_enum_repo_v3"), default=ProtocolSourceStatusEnum.ACTIVE, nullable=False)
+    auto_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     function_protocol_definitions = relationship("FunctionProtocolDefinitionOrm", back_populates="source_repository")
 
     def __repr__(self):
@@ -71,13 +67,13 @@ class ProtocolSourceRepositoryOrm(Base):
 
 class FileSystemProtocolSourceOrm(Base):
     __tablename__ = "file_system_protocol_sources"
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False, unique=True, index=True)
-    base_path = Column(String, nullable=False)
-    is_recursive = Column(Boolean, default=True)
-    status = Column(SAEnum(ProtocolSourceStatusEnum, name="ps_status_enum_fs_v3"), default=ProtocolSourceStatusEnum.ACTIVE, nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    base_path: Mapped[str] = mapped_column(String, nullable=False)
+    is_recursive: Mapped[bool] = mapped_column(Boolean, default=True)
+    status: Mapped[ProtocolSourceStatusEnum] = mapped_column(SAEnum(ProtocolSourceStatusEnum, name="ps_status_enum_fs_v3"), default=ProtocolSourceStatusEnum.ACTIVE, nullable=False)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     function_protocol_definitions = relationship("FunctionProtocolDefinitionOrm", back_populates="file_system_source")
 
     def __repr__(self):
@@ -86,26 +82,26 @@ class FileSystemProtocolSourceOrm(Base):
 # --- Static Protocol Definition Tables ---
 class FunctionProtocolDefinitionOrm(Base):
     __tablename__ = "function_protocol_definitions"
-    id = Column(Integer, primary_key=True, index=True)
-    name = Column(String, nullable=False, index=True)
-    version = Column(String, nullable=False, default="0.1.0")
-    description = Column(Text, nullable=True)
-    source_file_path = Column(String, nullable=False)
-    module_name = Column(String, nullable=False, index=True)
-    function_name = Column(String, nullable=False)
-    source_repository_id = Column(Integer, ForeignKey("protocol_source_repositories.id"), nullable=True)
-    commit_hash = Column(String, nullable=True, index=True)
-    file_system_source_id = Column(Integer, ForeignKey("file_system_protocol_sources.id"), nullable=True)
-    is_top_level = Column(Boolean, default=False, index=True)
-    solo_execution = Column(Boolean, default=False)
-    preconfigure_deck = Column(Boolean, default=False)
-    deck_param_name = Column(String, nullable=True)
-    state_param_name = Column(String, nullable=True, comment="Name of the state parameter in the function signature.")
-    category = Column(String, nullable=True, index=True)
-    tags = Column(JSON, nullable=True)
-    deprecated = Column(Boolean, default=False, index=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    version: Mapped[str] = mapped_column(String, nullable=False, default="0.1.0")
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    source_file_path: Mapped[str] = mapped_column(String, nullable=False)
+    module_name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    function_name: Mapped[str] = mapped_column(String, nullable=False)
+    source_repository_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("protocol_source_repositories.id"), nullable=True)
+    commit_hash: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True)
+    file_system_source_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("file_system_protocol_sources.id"), nullable=True)
+    is_top_level: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    solo_execution: Mapped[bool] = mapped_column(Boolean, default=False)
+    preconfigure_deck: Mapped[bool] = mapped_column(Boolean, default=False)
+    deck_param_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    state_param_name: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="Name of the state parameter in the function signature.")
+    category: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True)
+    tags: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict as per refined instructions
+    deprecated: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     parameters = relationship("ParameterDefinitionOrm", back_populates="protocol_definition", cascade="all, delete-orphan")
     assets = relationship("AssetDefinitionOrm", back_populates="protocol_definition", cascade="all, delete-orphan")
@@ -124,16 +120,16 @@ class FunctionProtocolDefinitionOrm(Base):
 
 class ParameterDefinitionOrm(Base):
     __tablename__ = "parameter_definitions"
-    id = Column(Integer, primary_key=True, index=True)
-    protocol_definition_id = Column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
-    name = Column(String, nullable=False)
-    type_hint_str = Column(String, nullable=False)
-    actual_type_str = Column(String, nullable=False)
-    is_deck_param = Column(Boolean, default=False)
-    optional = Column(Boolean, nullable=False)
-    default_value_repr = Column(String, nullable=True)
-    description = Column(Text, nullable=True)
-    constraints_json = Column("constraints", JSON, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    protocol_definition_id: Mapped[int] = mapped_column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    type_hint_str: Mapped[str] = mapped_column(String, nullable=False)
+    actual_type_str: Mapped[str] = mapped_column(String, nullable=False)
+    is_deck_param: Mapped[bool] = mapped_column(Boolean, default=False)
+    optional: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    default_value_repr: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    constraints_json: Mapped[Optional[dict]] = mapped_column("constraints", JSON, nullable=True) # Using dict
     protocol_definition = relationship("FunctionProtocolDefinitionOrm", back_populates="parameters")
     __table_args__ = (UniqueConstraint('protocol_definition_id', 'name', name='uq_param_def_name_per_protocol_v3'),)
 
@@ -142,15 +138,15 @@ class ParameterDefinitionOrm(Base):
 
 class AssetDefinitionOrm(Base):
     __tablename__ = "asset_definitions"
-    id = Column(Integer, primary_key=True, index=True)
-    protocol_definition_id = Column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
-    name = Column(String, nullable=False)
-    type_hint_str = Column(String, nullable=False)
-    actual_type_str = Column(String, nullable=False)
-    optional = Column(Boolean, nullable=False)
-    default_value_repr = Column(String, nullable=True)
-    description = Column(Text, nullable=True)
-    constraints_json = Column("constraints", JSON, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    protocol_definition_id: Mapped[int] = mapped_column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    type_hint_str: Mapped[str] = mapped_column(String, nullable=False)
+    actual_type_str: Mapped[str] = mapped_column(String, nullable=False)
+    optional: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    default_value_repr: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    constraints_json: Mapped[Optional[dict]] = mapped_column("constraints", JSON, nullable=True) # Using dict
     protocol_definition = relationship("FunctionProtocolDefinitionOrm", back_populates="assets")
     __table_args__ = (UniqueConstraint('protocol_definition_id', 'name', name='uq_asset_def_name_per_protocol_v3'),)
 
@@ -159,22 +155,22 @@ class AssetDefinitionOrm(Base):
 
 class ProtocolRunOrm(Base):
     __tablename__ = "protocol_runs"
-    id = Column(Integer, primary_key=True, index=True)
-    run_guid = Column(String, nullable=False, unique=True, index=True)
-    top_level_protocol_definition_id = Column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
-    status = Column(SAEnum(ProtocolRunStatusEnum, name="protocol_run_status_enum_v3"), default=ProtocolRunStatusEnum.PENDING, nullable=False, index=True)
-    start_time = Column(DateTime(timezone=True), nullable=True)
-    end_time = Column(DateTime(timezone=True), nullable=True)
-    duration_ms = Column(Integer, nullable=True)
-    input_parameters_json = Column(JSON, nullable=True)
-    resolved_assets_json = Column(JSON, nullable=True)
-    output_data_json = Column(JSON, nullable=True)
-    initial_state_json = Column(JSON, nullable=True)
-    final_state_json = Column(JSON, nullable=True)
-    data_directory_path = Column(String, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    run_guid: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    top_level_protocol_definition_id: Mapped[int] = mapped_column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
+    status: Mapped[ProtocolRunStatusEnum] = mapped_column(SAEnum(ProtocolRunStatusEnum, name="protocol_run_status_enum_v3"), default=ProtocolRunStatusEnum.PENDING, nullable=False, index=True)
+    start_time: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    end_time: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    input_parameters_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    resolved_assets_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    output_data_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    initial_state_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    final_state_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    data_directory_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     # created_by_user_id = Column(Integer, ForeignKey("users.id"), nullable=True) # TODO: PDS-5
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
     top_level_protocol_definition = relationship("FunctionProtocolDefinitionOrm", back_populates="protocol_runs")
     function_calls = relationship("FunctionCallLogOrm", back_populates="protocol_run", cascade="all, delete-orphan", order_by="FunctionCallLogOrm.sequence_in_run")
 
@@ -184,19 +180,19 @@ class ProtocolRunOrm(Base):
 
 class FunctionCallLogOrm(Base):
     __tablename__ = "function_call_logs"
-    id = Column(Integer, primary_key=True, index=True)
-    protocol_run_id = Column(Integer, ForeignKey("protocol_runs.id"), nullable=False, index=True)
-    sequence_in_run = Column(Integer, nullable=False)
-    function_protocol_definition_id = Column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
-    parent_function_call_log_id = Column(Integer, ForeignKey("function_call_logs.id"), nullable=True)
-    start_time = Column(DateTime(timezone=True), nullable=False)
-    end_time = Column(DateTime(timezone=True), nullable=True)
-    duration_ms = Column(Integer, nullable=True)
-    input_args_json = Column(JSON, nullable=True)
-    return_value_json = Column(JSON, nullable=True)
-    status = Column(SAEnum(FunctionCallStatusEnum, name="function_call_status_enum_v3"), nullable=False)
-    error_message_text = Column(Text, nullable=True)
-    error_traceback_text = Column(Text, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    protocol_run_id: Mapped[int] = mapped_column(Integer, ForeignKey("protocol_runs.id"), nullable=False, index=True)
+    sequence_in_run: Mapped[int] = mapped_column(Integer, nullable=False)
+    function_protocol_definition_id: Mapped[int] = mapped_column(Integer, ForeignKey("function_protocol_definitions.id"), nullable=False)
+    parent_function_call_log_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("function_call_logs.id"), nullable=True)
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    end_time: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    input_args_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    return_value_json: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True) # Using dict
+    status: Mapped[FunctionCallStatusEnum] = mapped_column(SAEnum(FunctionCallStatusEnum, name="function_call_status_enum_v3"), nullable=False)
+    error_message_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    error_traceback_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     protocol_run = relationship("ProtocolRunOrm", back_populates="function_calls")
     executed_function_definition = relationship("FunctionProtocolDefinitionOrm", foreign_keys=[function_protocol_definition_id], back_populates="function_call_logs")
     parent_call = relationship("FunctionCallLogOrm", remote_side=[id], backref="child_calls") # type: ignore

--- a/praxis/backend/database_models/user_management_orm.py
+++ b/praxis/backend/database_models/user_management_orm.py
@@ -1,33 +1,28 @@
 # praxis/backend/database_models/user_management_orm.py
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
-from sqlalchemy.orm import relationship # If relationships are needed later
+from datetime import datetime
+from typing import Optional
 
-# Ensure this import path for Base is correct for your project structure.
-try:
-    from praxis.backend.utils.db import Base # Import your project's Base
-except ImportError:
-    # This is a fallback for cases where the model might be used standalone
-    # or if the path changes. For actual application runs, the above import should work.
-    print("WARNING: Could not import Base from praxis.backend.utils.db. Using a local Base for UserOrm definition only.")
-    from sqlalchemy.orm import declarative_base
-    Base = declarative_base()
+from sqlalchemy import Integer, String, Boolean, DateTime, func # Removed Column
+from sqlalchemy.orm import relationship, Mapped, mapped_column # Added Mapped, mapped_column
+
+from praxis.backend.utils.db import Base # Import your project's Base
 
 class UserOrm(Base):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, unique=True, index=True, nullable=False)
-    email = Column(String, unique=True, index=True, nullable=False)
-    hashed_password = Column(String, nullable=False)
-    full_name = Column(String, nullable=True)
-    is_active = Column(Boolean, default=True, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    username: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+    full_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     
-    phone_number = Column(String, nullable=True, index=True, comment="User's phone number for SMS notifications")
-    phone_carrier = Column(String, nullable=True, comment="User's phone carrier for SMS gateway emails, e.g., 'verizon', 'att'")
+    phone_number: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True, comment="User's phone number for SMS notifications")
+    phone_carrier: Mapped[Optional[str]] = mapped_column(String, nullable=True, comment="User's phone carrier for SMS gateway emails, e.g., 'verizon', 'att'")
     # TODO: Add is_superuser or roles if needed for authorization
 
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     # Example of a relationship if UserOrm links to other tables in the future
     # protocol_runs = relationship("ProtocolRunOrm", back_populates="created_by_user")

--- a/praxis/backend/utils/db.py
+++ b/praxis/backend/utils/db.py
@@ -1,6 +1,6 @@
 import os
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
-from sqlalchemy.orm import declarative_base
+from sqlalchemy.orm import DeclarativeBase # Changed from declarative_base
 from configparser import ConfigParser
 from pathlib import Path
 from typing import AsyncGenerator
@@ -93,7 +93,8 @@ AsyncSessionLocal = async_sessionmaker(
 )
 
 # --- Base for ORM Models ---
-Base = declarative_base()
+class Base(DeclarativeBase): # Changed from Base = declarative_base()
+    pass
 
 # --- Dependency for FastAPI Routes to Get an Async DB Session ---
 async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:


### PR DESCRIPTION
- I modified `praxis.backend.utils.db.Base` to use `class Base(DeclarativeBase): pass` for SQLAlchemy 2.0 compatibility.
- I simplified `Base` import in ORM model files (`asset_management_orm.py`, `protocol_definitions_orm.py`, `user_management_orm.py`) by removing redundant try-except blocks.
- I updated comments for `plr_category` and `python_fqn` fields in `LabwareDefinitionCatalogOrm` in `asset_management_orm.py` to better align with PyLabRobot ontology naming and FQN conventions.